### PR TITLE
added: alt text to loading.gif

### DIFF
--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -97,9 +97,9 @@ function the_ratings($start_tag = 'div', $custom_id = 0, $display = true) {
 	// Loading Style
 	$postratings_ajax_style = get_option('postratings_ajax_style');
 	if ( (int) $postratings_ajax_style['loading'] === 1 ) {
-		$loading_alt = apply_filters('wp_postratings_loading_alt', '');
+		$loading_alt = apply_filters('wp_postratings_loading_alt', 'loading post rating');
 		$loading_alt_html = ! empty( $loading_alt ) ? ' alt="' . esc_attr( $loading_alt ) . '"' : '';
-		$loading = '<' . $start_tag . ' id="post-ratings-' . $ratings_id . '-loading" class="post-ratings-loading"><img src="' . plugins_url('wp-postratings/images/loading.gif') . '" width="16" height="16" alt="loading rating" class="post-ratings-image"' . $loading_alt_html . ' />' . esc_html__( 'Loading...', 'wp-postratings' ) . '</' . $start_tag . '>';
+		$loading = '<' . $start_tag . ' id="post-ratings-' . $ratings_id . '-loading" class="post-ratings-loading"><img src="' . plugins_url('wp-postratings/images/loading.gif') . '" width="16" height="16" class="post-ratings-image"' . $loading_alt_html . ' />' . esc_html__( 'Loading...', 'wp-postratings' ) . '</' . $start_tag . '>';
 	} else {
 		$loading = '';
 	}

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -99,7 +99,7 @@ function the_ratings($start_tag = 'div', $custom_id = 0, $display = true) {
 	if ( (int) $postratings_ajax_style['loading'] === 1 ) {
 		$loading_alt = apply_filters('wp_postratings_loading_alt', '');
 		$loading_alt_html = ! empty( $loading_alt ) ? ' alt="' . esc_attr( $loading_alt ) . '"' : '';
-		$loading = '<' . $start_tag . ' id="post-ratings-' . $ratings_id . '-loading" class="post-ratings-loading"><img src="' . plugins_url('wp-postratings/images/loading.gif') . '" width="16" height="16" class="post-ratings-image"' . $loading_alt_html . ' />' . esc_html__( 'Loading...', 'wp-postratings' ) . '</' . $start_tag . '>';
+		$loading = '<' . $start_tag . ' id="post-ratings-' . $ratings_id . '-loading" class="post-ratings-loading"><img src="' . plugins_url('wp-postratings/images/loading.gif') . '" width="16" height="16" alt="loading rating" class="post-ratings-image"' . $loading_alt_html . ' />' . esc_html__( 'Loading...', 'wp-postratings' ) . '</' . $start_tag . '>';
 	} else {
 		$loading = '';
 	}


### PR DESCRIPTION
The alt text of loading.gif was missing that is not nice for SEO. 
This gif appears in the source code only if "Show loading image with text" option is activated in WP admin plugin settings.  